### PR TITLE
Add selinux profile

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -25,5 +25,5 @@ mod 'puppetlabs-mysql', '3.9.0'
 mod 'puppet-staging', '2.0.1'
 mod 'puppetlabs-concat', '2.2.0'
 mod 'puppetlabs-apache', '1.10.0'
-
+mod 'puppetlabs-reboot', '1.2.1'
 

--- a/site/profile/manifests/linux/selinux.pp
+++ b/site/profile/manifests/linux/selinux.pp
@@ -1,0 +1,13 @@
+class profile::linux::selinux {
+  include stdlib
+
+  class { 'profile::linux::selinux::setup':
+    stage => 'setup',
+  }
+
+  reboot { 'selinux':
+    apply     => finished,
+    subscribe => Class['profile::linux::selinux::setup'],
+  }
+
+}

--- a/site/profile/manifests/linux/selinux/setup.pp
+++ b/site/profile/manifests/linux/selinux/setup.pp
@@ -1,0 +1,21 @@
+# This class is intended to be declared to run in the setup stage
+class profile::linux::selinux::setup {
+
+  ini_setting { 'selinux':
+    ensure            => present,
+    path              => '/etc/selinux/config',
+    section           => '',
+    setting           => 'SELINUX',
+    value             => 'disabled',
+    key_val_separator => '=',
+  }
+
+  exec { 'ensure selinux not enforcing':
+    path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+    command => 'setenforce Permissive',
+    unless  => 'getenforce | grep -i disabled',
+    require => Ini_setting['selinux'],
+    notify  => Reboot['selinux'],
+  }
+
+}

--- a/site/profile/manifests/wordpress/app.pp
+++ b/site/profile/manifests/wordpress/app.pp
@@ -3,6 +3,7 @@ class profile::wordpress::app (
 ) {
   include apache
   include apache::mod::php
+  include profile::linux::selinux
   
   apache::vhost { 'wordpress':
     vhost_name => '*',

--- a/site/profile/manifests/wordpress/db.pp
+++ b/site/profile/manifests/wordpress/db.pp
@@ -1,4 +1,5 @@
 class profile::wordpress::db {
+  include profile::linux::selinux
 
   class { '::mysql::server':
     root_password           => lookup('wordpress_passwd'),


### PR DESCRIPTION
This will disable SELinux on the Wordpress servers. This is necessary
since we aren't bothering to do the proper SELinux configuration
necessary to serve Wordpress otherwise.
